### PR TITLE
Fix song-list grid size on desktop

### DIFF
--- a/src/components/SongList.css
+++ b/src/components/SongList.css
@@ -1,6 +1,6 @@
 #song-list {
     grid-column: 6/13;
-    grid-row: 3/6;
+    grid-row: 3/8;
     overflow-y: auto;
     overflow-x: hidden;
     padding-left: 2px;
@@ -26,9 +26,10 @@
     background: #ccc;
 }
 
-@media (max-width: 760px) {
+@media (max-width: 720px) {
     #song-list {
         grid-column: 1/13;
+        grid-row: 3/6;
     }
 }
 


### PR DESCRIPTION
The changed grid from #1 size would cause some songs to be hidden when zooming the desktop page. This change ensures the songs always take of the full height on desktop view and will leave space for current view in mobile.

In addition, the mediatag for song list updates was inconsistently set to 760px. Throughout the project we only know small <720px and large >720px. This is fixed as well.

Before 
![image](https://user-images.githubusercontent.com/15729893/167799784-2c59b48b-b690-4669-ba9c-c96fe70d60c6.png)

After: 
![image](https://user-images.githubusercontent.com/15729893/167799879-ebb7aad6-c26a-479a-ad2c-fabea3b8c594.png)
